### PR TITLE
New 'about' text that mentions alpha status

### DIFF
--- a/config/long_description.md
+++ b/config/long_description.md
@@ -1,3 +1,4 @@
+# About the British Library's Playbills collection
 The British Library holds a considerable collection of Playbills dating from the 
 1730s to the 1950s. These are single-sheet items which list entertainments at 
 theatres, fairs, pleasure gardens and other such venues. Small 'handbills' 
@@ -7,35 +8,43 @@ bound volumes, comprising an estimated 234,000 playbills.
 
 Given the ephemeral nature of Playbills (fires always needed lighting!) we are 
 fortunate to have such a large number survive, thanks largely to the zeal of 
-known collectors who gathered them together. These preserved Playbills offer a 
-wealth of historical detail with thousands of personal names of actors, 
-playwrights, composers, and theatre managers. Titles in characteristic large 
+known collectors who gathered them together. Titles in characteristic large 
 type indicate the range and frequency of popular performances and much-loved 
 dramas but, equally important, glimpses the less well-known and even forgotten 
-plays. 
+plays. Each Playbill is a glimpse into past entertainments. Some of these 
+Playbills have been digitised - and now we need your help to 
+bring them back into the spotlight.
 
-These promising rich details have been so near yet so far from our fingertips 
-because past constraints have left this mass of historical print largely 
-uncatalogued. Some volumes are listed on [Explore](http://explore.bl.uk) but the entries do not expand beyond naming a location (town), particular theatre(s), and giving an indication of approximate date(s).
+# About the *In the Spotlight* project
+Our newest crowdsourcing project, *In the Spotlight* is in 'alpha' - that 
+means it's work-in-progress and we suspect there are still lots of little 
+issues to sort out. 
 
-Current catalogue searching cannot uncover the level of detail important to 
+Please have a go and do let us know what you think: do the instructions 
+make sense? Do the tasks work as you expected? Is there too much to 
+transcribe, too little? Are you comfortable using the forum to discuss 
+the playbills? Are there tasks you'd like to suggest for the pages
+you've seen?
+
+You can help by posting feedback on the 
+[project forum](https://community.libcrowds.com/), emailing us digitalresearch@bl.uk or tweeting @[BL_DigiSchol](https://twitter.com/BL_DigiSchol).
+
+# How your contributions to *In the Spotlight* make a difference
+These preserved Playbills offer a wealth of historical detail with 
+thousands of personal names of actors, playwrights, composers, and 
+theatre managers. But these promising rich details have been so near 
+yet so far from our fingertips because past constraints have left this 
+mass of historical print largely uncatalogued. Some volumes are 
+listed on [Explore](http://explore.bl.uk) but the entries do not 
+expand beyond naming a location (town), particular theatre(s), 
+and giving an indication of approximate date(s).
+
+Current catalogue searches cannot recover the level of detail important to 
 researchers: no titles; no names of actors, dramatis personae; no dates of 
 performance, or details of songs performed. Such indications can be crucial to 
 informing and guiding selection of material for closer examination.
 
-Large numbers of Playbills have now been digitised and can be freely viewed on 
-the main catalogue [Explore the British Library](http://explore.bl.uk). 
-But, the detail is buried.
-
-Transcribing selected key components from individual playbills can be uploaded 
-to Explore and will help permanently enhance the way they can be found and 
-reviewed. Something that can be fun to read can be captured and recorded for 
-others to discover and interpret.
-
-Some of these plays may not have been independently recorded in printed form in 
-playbooks; some songs may not have been committed to any printed score so some 
-transcriptions will undoubtedly prove pioneering and help expose hidden details.
-
-This is a work-in-progress, so please have a go and do let us know what you 
-think: is there too much to transcribe, too little? Would a free-text box for 
-additional comments be helpful? 
+By marking and transcribing titles, genres, personal names, locations and dates,
+you'll help bring these Playbills back into the spotlight. Transcribed information
+will be tidied up and put into the catalogue records, and to further aid research,
+the data is always available to download from this site.


### PR DESCRIPTION
Added headers, section on 'alpha' and tweaked other text. Needs to be merged with the current text at https://playbills.libcrowds.com/about